### PR TITLE
feat: implement express connect onboarding route and coach profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,5 @@ SMTP_USER=
 SMTP_PASS=
 
 # --- App ---
+# Base URL for building absolute links
 APP_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .env.*
 !.env.example
 .DS_Store
+tsconfig.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ npm run dev
 ## Supabase
 - Paste `supabase/schema.sql` into the SQL editor (or run as a migration).
 - Turn on RLS and craft policies for each table.
+- Run `npm run seed:coaches` locally to insert demo coach profiles. The script reads
+  `NEXT_PUBLIC_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` from your environment
+  and must never run in the browser.
 
 ## Stripe
 - Forward webhooks: `stripe listen --forward-to localhost:3000/api/stripe/webhook`
@@ -39,3 +42,26 @@ npm run dev
 
 ## Email
 - Fill SMTP or Resend credentials. See `lib/email.ts` and `/api/email/send`.
+
+## Environment Variables
+
+Set the following variables in Vercel. "Preview" refers to Preview Deployments; "Production" covers the Production Deployment.
+
+| Variable | Purpose | Preview | Production |
+| --- | --- | --- | --- |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL | Yes | Yes |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key for browser requests | Yes | Yes |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key for server tasks | Yes | Yes |
+| `STRIPE_SECRET_KEY` | Stripe secret key for server-side API calls | Yes | Yes |
+| `STRIPE_WEBHOOK_SECRET` | Validates Stripe webhooks | Yes | Yes |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key for client-side UI | Optional | Yes |
+| `STRIPE_CONNECT_CLIENT_ID` | Connect onboarding client ID | Optional | Yes |
+| `APP_URL` | Base URL used for redirects and links | Yes | Yes |
+| `ZOOM_VERIFICATION_TOKEN` | Zoom webhook verification | Optional | Yes |
+| `ZOOM_CLIENT_ID` | Zoom OAuth client ID | Optional | Optional |
+| `ZOOM_CLIENT_SECRET` | Zoom OAuth client secret | Optional | Optional |
+| `RESEND_API_KEY` | Resend email API key | Optional | Optional |
+| `SMTP_HOST` | SMTP server host | Optional | Optional |
+| `SMTP_PORT` | SMTP port | Optional | Optional |
+| `SMTP_USER` | SMTP username | Optional | Optional |
+| `SMTP_PASS` | SMTP password | Optional | Optional |

--- a/app/_components/Header.module.css
+++ b/app/_components/Header.module.css
@@ -1,0 +1,14 @@
+.header {
+  padding: 1rem;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav a {
+  text-decoration: none;
+  color: inherit;
+}

--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -1,0 +1,13 @@
+import Link from "next/link";
+import styles from "./Header.module.css";
+
+export default function Header() {
+  return (
+    <header className={styles.header}>
+      <nav className={styles.nav}>
+        <Link href="/">Home</Link>
+        <Link href="/coaches">Coaches</Link>
+      </nav>
+    </header>
+  );
+}

--- a/app/api/ping/route.ts
+++ b/app/api/ping/route.ts
@@ -1,0 +1,6 @@
+export async function GET() {
+  return new Response("pong", {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  });
+}

--- a/app/api/stripe/connect-onboard/route.ts
+++ b/app/api/stripe/connect-onboard/route.ts
@@ -1,28 +1,91 @@
-import { NextRequest } from "next/server";
 import Stripe from "stripe";
+import { adminClient } from "@/supabase/client";
 
-export async function POST(_req: NextRequest) {
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
-    apiVersion: "2024-06-20" as any,
-  });
+/**
+ * Handles Stripe Connect Express onboarding requests.
+ *
+ * The route validates required environment variables, creates a connected
+ * account, generates onboarding links, and returns the link and account ID.
+ */
+export async function POST() {
+  // Log that the endpoint has received a request.
+  console.log("Stripe Connect onboarding route started");
 
-  // Create a connected account (Express) for MVP
-  const account = await stripe.accounts.create({
-    type: "express",
-    country: "US",
-    business_type: "individual",
-    capabilities: { card_payments: { requested: true }, transfers: { requested: true } },
-  });
+  // Retrieve and verify the Stripe secret key.
+  const secretKey = process.env.STRIPE_SECRET_KEY;
+  if (!secretKey) {
+    return new Response(
+      JSON.stringify({ error: "Missing STRIPE_SECRET_KEY" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
 
+  // Retrieve and verify the application base URL used for redirects.
+  const appUrl = process.env.APP_URL;
+  if (!appUrl) {
+    return new Response(JSON.stringify({ error: "Missing APP_URL" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Ensure APP_URL is a valid absolute URL before using it.
+  let baseUrl: URL;
+  try {
+    baseUrl = new URL(appUrl);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid APP_URL" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Initialize the Stripe SDK with the specified API version.
+  const stripe = new Stripe(secretKey, { apiVersion: "2024-06-20" });
+
+  // Create an Express connected account for the user.
+  const account = await stripe.accounts.create({ type: "express" });
+
+  // Persist the new account ID in Supabase if possible.
+  try {
+    const supabase = adminClient();
+    await supabase
+      .from("stripe_accounts")
+      .insert({ account_id: account.id });
+  } catch (error) {
+    console.error("Failed to store Stripe account", error);
+  }
+
+  // Build absolute URLs for refresh and return redirects.
+  const refreshUrl = new URL("/dashboard?onboard=refresh", baseUrl).toString();
+  const returnUrl = new URL(
+    `/dashboard?onboard=done&acct=${account.id}`,
+    baseUrl,
+  ).toString();
+
+  // Create an onboarding link directing the user to Stripe.
   const accountLink = await stripe.accountLinks.create({
     account: account.id,
-    refresh_url: `${process.env.APP_URL}/dashboard?onboard=refresh`,
-    return_url: `${process.env.APP_URL}/dashboard?onboard=done&acct=${account.id}`,
+    refresh_url: refreshUrl,
+    return_url: returnUrl,
     type: "account_onboarding",
   });
 
-  return new Response(JSON.stringify({ accountId: account.id, url: accountLink.url }), {
-    status: 200,
-    headers: { "Content-Type": "application/json" },
+  // Log completion details for debugging and traceability.
+  console.log("Stripe account link creation finished", {
+    accountId: account.id,
+    url: accountLink.url,
   });
+
+  // Return the account ID and onboarding URL to the client.
+  return new Response(
+    JSON.stringify({ accountId: account.id, url: accountLink.url }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
 }

--- a/app/api/test-supabase/route.ts
+++ b/app/api/test-supabase/route.ts
@@ -1,0 +1,24 @@
+import supabase from "@/supabase/client";
+
+/**
+ * Simple route that returns `id`, `full_name`, and `role` fields
+ * from the `profiles` table using the anonymous Supabase client.
+ */
+export async function GET() {
+  const { data, error } = await supabase
+    .from("profiles")
+    .select("id, full_name, role");
+
+  if (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+

--- a/app/coaches/[id]/page.tsx
+++ b/app/coaches/[id]/page.tsx
@@ -1,0 +1,78 @@
+import supabase from "@/supabase/client";
+import styles from "../styles.module.css";
+
+interface Profile {
+  full_name: string | null;
+  role: string | null;
+  avatar_url: string | null;
+}
+
+function getInitials(name: string | null) {
+  if (!name) return "?";
+  return name
+    .split(/\s+/)
+    .map((n) => n[0])
+    .filter(Boolean)
+    .join("")
+    .toUpperCase();
+}
+
+export default async function CoachPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  try {
+    const { data: profile, error } = await supabase
+      .from("profiles")
+      .select("full_name, role, avatar_url")
+      .eq("id", params.id)
+      .maybeSingle();
+
+    if (error) {
+      console.error("Error loading coach profile:", error);
+      return (
+        <main className={styles.container}>
+          <div className={styles.emptyState}>Failed to load coach.</div>
+        </main>
+      );
+    }
+
+    if (!profile) {
+      return (
+        <main className={styles.container}>
+          <div className={styles.emptyState}>Coach not found.</div>
+        </main>
+      );
+    }
+
+    return (
+      <main className={styles.container}>
+        <div className={styles.profileHeader}>
+          <div className={styles.avatar}>
+            {profile.avatar_url ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={profile.avatar_url} alt={profile.full_name ?? "Coach"} />
+            ) : (
+              getInitials(profile.full_name)
+            )}
+          </div>
+          <div className={styles.name}>{profile.full_name ?? "Unnamed"}</div>
+          <div className={styles.role}>{profile.role ?? ""}</div>
+        </div>
+        <section>
+          <h2>Listings</h2>
+          <div className={styles.emptyState}>No listings yet.</div>
+        </section>
+      </main>
+    );
+  } catch (err) {
+    console.error("Unexpected error loading coach profile:", err);
+    return (
+      <main className={styles.container}>
+        <div className={styles.emptyState}>Failed to load coach.</div>
+      </main>
+    );
+  }
+}
+

--- a/app/coaches/page.tsx
+++ b/app/coaches/page.tsx
@@ -1,0 +1,79 @@
+import supabase from "@/supabase/client";
+import Link from "next/link";
+import styles from "./styles.module.css";
+
+interface Profile {
+  id: string;
+  full_name: string | null;
+  role: string | null;
+  avatar_url: string | null;
+}
+
+function getInitials(name: string | null) {
+  if (!name) return "?";
+  return name
+    .split(/\s+/)
+    .map((n) => n[0])
+    .filter(Boolean)
+    .join("")
+    .toUpperCase();
+}
+
+export default async function CoachesPage() {
+  try {
+    const { data: profiles, error } = await supabase
+      .from("profiles")
+      .select("id, full_name, role, avatar_url")
+      .eq("role", "coach");
+
+    if (error) throw error;
+
+    if (!profiles || profiles.length === 0) {
+      return (
+        <main className={styles.container}>
+          <h1>Coaches</h1>
+          <div className={styles.emptyState}>No coaches found.</div>
+        </main>
+      );
+    }
+
+    return (
+      <main className={styles.container}>
+        <h1>Coaches</h1>
+        <div className={styles.grid}>
+          {profiles.map((profile: Profile) => (
+            <Link
+              key={profile.id}
+              href={`/coaches/${profile.id}`}
+              className={styles.card}
+            >
+              <div className={styles.avatar}>
+                {profile.avatar_url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={profile.avatar_url}
+                    alt={profile.full_name ?? "Coach"}
+                  />
+                ) : (
+                  getInitials(profile.full_name)
+                )}
+              </div>
+              <div className={styles.name}>
+                {profile.full_name ?? "Unnamed"}
+              </div>
+              <div className={styles.role}>{profile.role ?? "unknown"}</div>
+            </Link>
+          ))}
+        </div>
+      </main>
+    );
+  } catch (err) {
+    console.error("Error loading coaches:", err);
+    return (
+      <main className={styles.container}>
+        <h1>Coaches</h1>
+        <div className={styles.emptyState}>Failed to load coaches.</div>
+      </main>
+    );
+  }
+}

--- a/app/coaches/styles.module.css
+++ b/app/coaches/styles.module.css
@@ -1,0 +1,66 @@
+.container {
+  padding: 2rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+  text-decoration: none;
+  color: inherit;
+  display: block;
+  cursor: pointer;
+}
+
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: #f5f5f5;
+  margin: 0 auto 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.name {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+
+.role {
+  color: #666;
+  font-size: 0.875rem;
+}
+
+
+
+.emptyState {
+  text-align: center;
+  padding: 2rem;
+  color: #666;
+}
+
+.profileHeader {
+  text-align: center;
+  margin-bottom: 2rem;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import "./globals.css";
 import type { Metadata } from "next";
+import Header from "./_components/Header";
 
 export const metadata: Metadata = {
   title: "TeachTape",
@@ -9,7 +10,10 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Header />
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,27 +1,8 @@
 export default function Page() {
   return (
-    <div>
-      <nav className="nav container">
-        <div><strong>TeachTape</strong></div>
-        <div>
-          <a className="btn" href="/dashboard">Dashboard</a>
-        </div>
-      </nav>
-      <header className="container">
-        <h1>Film breakdowns and live lessons with real coaches</h1>
-        <p>Launch your skills. Book vetted coaches for 1:1 training and video analysis.</p>
-        <a className="btn" href="/dashboard">Get started</a>
-      </header>
-      <section className="container">
-        <div className="grid">
-          <div className="card"><h3>Verified coaches</h3><p>Background-checked, rated by athletes.</p></div>
-          <div className="card"><h3>Zoom-native</h3><p>Auto-schedules meetings and sends links.</p></div>
-          <div className="card"><h3>Secure payments</h3><p>Stripe Connect with instant payouts.</p></div>
-        </div>
-      </section>
-      <footer className="footer container">
-        © {new Date().getFullYear()} TeachTape — MVP starter
-      </footer>
-    </div>
+    <main className="container" style={{ padding: "2rem 0" }}>
+      <h1 style={{ fontSize: "2.5rem", marginBottom: "1.5rem" }}>TeachTape</h1>
+      <a className="btn" href="/coaches">Browse coaches</a>
+    </main>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/react": "18.3.3",
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.5",
+        "tsx": "4.7.0",
         "typescript": "5.4.5"
       }
     },
@@ -772,6 +773,397 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
+      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
+      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
+      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
+      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
+      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
+      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
+      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
+      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
+      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
+      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
+      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
+      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
+      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
+      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
+      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
+      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
+      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
+      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
+      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
+      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
+      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
+      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3379,6 +3771,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.19.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
+      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.19.12",
+        "@esbuild/android-arm": "0.19.12",
+        "@esbuild/android-arm64": "0.19.12",
+        "@esbuild/android-x64": "0.19.12",
+        "@esbuild/darwin-arm64": "0.19.12",
+        "@esbuild/darwin-x64": "0.19.12",
+        "@esbuild/freebsd-arm64": "0.19.12",
+        "@esbuild/freebsd-x64": "0.19.12",
+        "@esbuild/linux-arm": "0.19.12",
+        "@esbuild/linux-arm64": "0.19.12",
+        "@esbuild/linux-ia32": "0.19.12",
+        "@esbuild/linux-loong64": "0.19.12",
+        "@esbuild/linux-mips64el": "0.19.12",
+        "@esbuild/linux-ppc64": "0.19.12",
+        "@esbuild/linux-riscv64": "0.19.12",
+        "@esbuild/linux-s390x": "0.19.12",
+        "@esbuild/linux-x64": "0.19.12",
+        "@esbuild/netbsd-x64": "0.19.12",
+        "@esbuild/openbsd-x64": "0.19.12",
+        "@esbuild/sunos-x64": "0.19.12",
+        "@esbuild/win32-arm64": "0.19.12",
+        "@esbuild/win32-ia32": "0.19.12",
+        "@esbuild/win32-x64": "0.19.12"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -4022,6 +4453,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -6730,6 +7176,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.7.0.tgz",
+      "integrity": "sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.19.10",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "version": "0.1.0",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "npm run check-env",
     "build": "next build",
     "start": "next start",
+    "test": "echo \"No tests yet\" && exit 0",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "check-env": "tsx scripts/check-env.ts",
+    "seed:coaches": "tsx scripts/seed-coaches.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "2.45.4",
@@ -25,6 +29,7 @@
     "@types/react": "18.3.3",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "tsx": "4.7.0"
   }
 }

--- a/scripts/check-env.ts
+++ b/scripts/check-env.ts
@@ -1,0 +1,31 @@
+/**
+ * Checks required environment variables for server and client contexts.
+ * Run during build to fail fast if any critical vars are missing.
+ */
+
+const required = {
+  server: [
+    "SUPABASE_SERVICE_ROLE_KEY",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "APP_URL",
+  ],
+  client: [
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  ],
+};
+
+function assertVars(vars: string[], scope: string) {
+  const missing = vars.filter((name) => !process.env[name]);
+  if (missing.length) {
+    throw new Error(
+      `Missing ${scope} environment variables: ${missing.join(", ")}`,
+    );
+  }
+}
+
+assertVars(required.server, "server");
+assertVars(required.client, "client");
+
+console.log("All required environment variables are present.");

--- a/scripts/seed-coaches.ts
+++ b/scripts/seed-coaches.ts
@@ -1,0 +1,57 @@
+/**
+ * One-time script to insert demo coach profiles into Supabase.
+ *
+ * Reads NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from the
+ * environment and must only be run on the server (never in the browser).
+ */
+import { randomUUID } from "crypto";
+import { adminClient } from "../supabase/client";
+
+const coaches = [
+  { full_name: "Alex Carter", avatar_url: "https://i.pravatar.cc/150?img=11" },
+  { full_name: "Jamie Brooks", avatar_url: "https://i.pravatar.cc/150?img=32" },
+  { full_name: "Taylor Reed", avatar_url: "https://i.pravatar.cc/150?img=7" },
+];
+
+async function seed() {
+  const supabase = adminClient();
+
+  for (const coach of coaches) {
+    const { data: existing, error: fetchError } = await supabase
+      .from("profiles")
+      .select("id")
+      .eq("full_name", coach.full_name)
+      .maybeSingle();
+
+    if (fetchError) {
+      console.error(`Failed to check ${coach.full_name}:`, fetchError.message);
+      continue;
+    }
+    if (existing) {
+      console.log(`Skipping ${coach.full_name} (already exists)`);
+      continue;
+    }
+
+    const { error: insertError } = await supabase.from("profiles").insert({
+      full_name: coach.full_name,
+      role: "coach",
+      avatar_url: coach.avatar_url,
+      auth_user_id: randomUUID(),
+    });
+
+    if (insertError) {
+      console.error(`Failed to insert ${coach.full_name}:`, insertError.message);
+    } else {
+      console.log(`Inserted ${coach.full_name}`);
+    }
+  }
+}
+
+seed()
+  .then(() => {
+    console.log("Seeding complete");
+  })
+  .catch((err) => {
+    console.error("Seeding failed:", err);
+    process.exit(1);
+  });

--- a/supabase/client.ts
+++ b/supabase/client.ts
@@ -3,7 +3,10 @@ import { createClient } from "@supabase/supabase-js";
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
-export const supabaseClient = createClient(supabaseUrl, supabaseAnonKey);
+const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export default supabase;
+export const supabaseClient = supabase;
 
 export function adminClient() {
   const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/testsupabase.ts
+++ b/testsupabase.ts
@@ -1,0 +1,5 @@
+import supabase from "@/supabase/client";
+
+export async function testSupabaseConnection() {
+  return supabase.from("test").select("*");
+}


### PR DESCRIPTION
## Summary
- document and format Stripe Connect onboarding steps with inline comments
- validate required env vars, build absolute URLs, and create Express accounts using Stripe API v2024-06-20
- log onboarding start and completion details, persisting Stripe account IDs through the local Supabase client
- add lint and placeholder test npm scripts
- export Supabase client for default imports and use it in testsupabase.ts
- add `/api/test-supabase` route that returns `id`, `full_name`, and `role` via the shared Supabase client
- add minimal `/api/ping` route for quick debugging
- add React Server Component `/coaches` page that lists coach names and roles from Supabase with graceful error handling
- style `/coaches` page as responsive cards with avatars, names, roles, and profile links, including empty and error states
- add dynamic `/coaches/[id]` page that fetches a coach’s info and listings with clean empty/error states and link from each coach card
- streamline `/coaches/[id]` server component to show profile details with a placeholder listings section and robust not-found/error handling
- add build-time env var checker and README table covering Supabase, Stripe, APP_URL and other keys
- add seed script for demo coaches using the service-role Supabase client
- add global Header component with navigation links and make coach cards link to individual profiles
- add a minimal landing page with headline and CTA to browse coaches

## Testing
- `npm test`
- `npm run lint` *(prompts for interactive ESLint configuration)*
- `npm run typecheck`
- `npm run check-env` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2af0b3e4c8328bae674873171a0b8